### PR TITLE
DBus slot fix and other cleanup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,9 @@ architectures:
 
 layout:
   /usr/lib/org.nickvision.tubeconverter:
-    bind: $SNAP/usr/lib/org.nickvision.tubeconverter
+    symlink: $SNAP/usr/lib/org.nickvision.tubeconverter
+  /usr/share/org.nickvision.tubeconverter:
+    symlink: $SNAP/usr/share/org.nickvision.tubeconverter
 
 environment:
   # WORKAROUND: Add python modules in Snap to search path

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,12 +142,14 @@ parts:
       sed -i "s|exec /usr/lib/org.nickvision.tubeconverter/NickvisionTubeConverter.GNOME|exec /snap/tube-converter/current/usr/lib/org.nickvision.tubeconverter/NickvisionTubeConverter.GNOME|" /root/prime/usr/bin/org.nickvision.tubeconverter
       sed -i "s|Exec=/usr/bin/org.nickvision.tubeconverter --gapplication-service|Exec=/snap/tube-converter/current/usr/bin/org.nickvision.tubeconverter --gapplication-service|" /root/prime/usr/share/dbus-1/services/org.nickvision.tubeconverter.service
     parse-info: [usr/share/metainfo/org.nickvision.tubeconverter.metainfo.xml]
-plugs:
+
+slots:
   # for GtkApplication registration
-  tube-converter-svc:
+  tube-converter:
     interface: dbus
     bus: session
     name: org.nickvision.tubeconverter    
+
 apps:
   tube-converter:
     command: usr/bin/org.nickvision.tubeconverter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,11 @@ architectures:
 #    interface: system-files
 #    read:
 #      - /usr/share/zoneinfo-icu/44/le/timezoneTypes.res
+
+layout:
+  /usr/lib/org.nickvision.tubeconverter:
+    bind: $SNAP/usr/lib/org.nickvision.tubeconverter
+
 environment:
   # WORKAROUND: Add python modules in Snap to search path
   PYTHONPATH: ${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages
@@ -129,7 +134,6 @@ parts:
     stage-packages:
       - python3
       - libpython3.10
-      - libnotify-bin
     override-pull: |
       craftctl default
       sed -e 's|Icon=org.nickvision.tubeconverter|Icon=/usr/share/icons/hicolor/scalable/apps/org.nickvision.tubeconverter.svg|' -i NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.desktop
@@ -138,9 +142,7 @@ parts:
       cd ~/parts/tube-converter/src/NickvisionTubeConverter.GNOME
       just publish-self-contained /usr
       just install /root/prime
-      sed -i "2 i export TC_PYTHON_SO=$TC_PYTHON_SO" /root/prime/usr/bin/org.nickvision.tubeconverter
-      sed -i "s|exec /usr/lib/org.nickvision.tubeconverter/NickvisionTubeConverter.GNOME|exec /snap/tube-converter/current/usr/lib/org.nickvision.tubeconverter/NickvisionTubeConverter.GNOME|" /root/prime/usr/bin/org.nickvision.tubeconverter
-      sed -i "s|Exec=/usr/bin/org.nickvision.tubeconverter --gapplication-service|Exec=/snap/tube-converter/current/usr/bin/org.nickvision.tubeconverter --gapplication-service|" /root/prime/usr/share/dbus-1/services/org.nickvision.tubeconverter.service
+      sed -i "2 i export TC_PYTHON_SO=$TC_PYTHON_SO" $CRAFT_PRIME/usr/bin/org.nickvision.tubeconverter
     parse-info: [usr/share/metainfo/org.nickvision.tubeconverter.metainfo.xml]
 
 slots:


### PR DESCRIPTION
    Don't stage libnotify-bin, nothing in the snap uses it.  Added a layout
    to ease path matching and reduce the number of sed operations.  Also
    don't bother using sed on the service file as there's nothing in the
    snap utilizing that anyway.

    The GtkApplication registration requires the slot side and it's best to
    name it the same as the app name as defined in the yaml.  This fixes the
    dbus denial.
