### PR TITLE
Override notification backend

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -162,7 +162,7 @@ apps:
     common-id: org.nickvision.tubeconverter
     environment:
       TC_PYTHON_SO: /snap/tube-converter/current/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0
-      GTK_USE_PORTAL: '1'
+      GNOTIFICATION_BACKEND: freedesktop
     desktop: usr/share/applications/org.nickvision.tubeconverter.desktop
     plugs:
       - home


### PR DESCRIPTION
Override notification backend and don't set GTK_USE_PORTAL as it's set by the gnome extension